### PR TITLE
Convert spaces and dashes to underscores in package name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,25 +160,31 @@ Example
 =======
 
 Below is an example showing exactly how to create a new Python project using
-this project. In this scenario the package is called ``example``.
+this project. In this scenario the package is called ``example_project``.
 
 At this point it is assumed that you have performed the actions outlined in
-the One Time Setup Steps section above. This provides a virtual environment that
-makes cookiecutter available.
+the One Time Setup Steps section above. This provides a virtual environment
+that makes cookiecutter available.
 
-Create the ``example`` project using cookiecutter.
+Create the ``example`` project using cookiecutter. The first question asks
+for the package display name. This human friendly label is used in docs to
+refer to the project. It is then used to create a candidate package name so
+it should not contain special characters that are invalid when used in a
+Python attribute. It can have spaces and hyphens in it. The package display
+name is first converted to lowercase text and then any spaces or hyphens are
+converted to underscores to produce a Python package name.
 
 .. code-block:: console
 
     (ccenv) $ cookiecutter ../python-project-template
-    package_name [package_name]: example
-    package_display_name [example]: Example
+    package_display_name [Example Project]: Example Project
+    package_name [package_name]: example_project
     package_short_description [A description of the package]: This package provides example capability
     version [0.0.1]:
     full_name [Your Name]: First Last
     email []:
     github_user_name [GithubUserName]: flast
-    github_repo_name [example]:
+    github_repo_name [example_project]:
     Select license:
     1 - MIT license
     2 - BSD license
@@ -190,11 +196,11 @@ Create the ``example`` project using cookiecutter.
     (ccenv) $ deactivate
     $
 
-The project has been created in the ``example`` directory.
+The project has been created in the ``example_project`` directory.
 
 .. code-block:: console
 
-    $ cd example
+    $ cd example_project
 
 We can now kick the tires of this new project by performing some initial
 project checks.
@@ -210,9 +216,9 @@ using the ``-e`` flag to ``pip``).
     ...
     Enter virtual environment using:
 
-      	source path/to/venvs/example/bin/activate
+      	source path/to/venvs/example_project/bin/activate
 
-    $ source path/to/venvs/example/bin/activate
+    $ source path/to/venvs/example_project/bin/activate
     (example) $
 
 Now that we have a virtual environment we can check the remaining convenience

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
-  "package_name": "package_name",
-  "package_display_name": "{{cookiecutter.package_name}}",
+  "package_display_name": "Package-Name",
+  "package_name": "{{cookiecutter.package_display_name.lower().replace(' ', '_').replace('-', '_')}}",
   "package_short_description": "A description of the package",
   "version": "0.0.1",
   "full_name": "Your Name",


### PR DESCRIPTION
This change adds behaviour to convert the supplied package display name into a candidate Python package name by replacing spaces and hyphens with underscores. This can make is slightly easier to create a valid package name while having a nice looking display name. This means a user does not necessarily need to know about valid Python naming.

- Update examples in docs to demonstrate this.
- Update ``cookiecutter.json`` to ask for display name first which can then be converted into a candidate package name.