### PR TITLE
minor fix to docs makefile

### DIFF
--- a/{{cookiecutter.package_name}}/docs/Makefile
+++ b/{{cookiecutter.package_name}}/docs/Makefile
@@ -1,5 +1,4 @@
 # Minimal makefile for Sphinx documentation
-#
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
@@ -9,12 +8,11 @@ SOURCEDIR     = source
 BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
+.PHONY: help
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
-
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+%:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/{{cookiecutter.package_name}}/docs/source/api/index.rst
+++ b/{{cookiecutter.package_name}}/docs/source/api/index.rst
@@ -1,0 +1,8 @@
+API
+###
+
+This section provides you with information on specific functions, classes and methods.
+
+.. toctree::
+
+   modules.rst


### PR DESCRIPTION
Clean up dependencies in Sphinx Makefile.

While reviewing the CI output I also noticed errors reported because the the ``docs/source/api/index.rst`` file was missing. Added this missing file to the project.