### PR TITLE
Use Black for code formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - cd example
   - pip install -r requirements.dev.txt
   - pip install -e .
-  - make check-style
+  - make style
   - make check-types
   - make test
   - make test-verbose

--- a/README.rst
+++ b/README.rst
@@ -223,14 +223,9 @@ using the ``-e`` flag to ``pip``).
 Now that we have a virtual environment we can check the remaining convenience
 functions provided by the Makefile.
 
-Note that ``make check-style`` step will raise a git-related error because the
-project is not yet controlled by git. The error occurs because the rule
-queries git for modified files. This error will not be seen once the project
-is under version control.
-
 .. code-block:: console
 
-    (abc_123) $ make check-style  # This will fail until git controlled
+    (abc_123) $ make style
     (abc_123) $ make check-types
     (abc_123) $ make test
     (abc_123) $ make test-verbose

--- a/{{cookiecutter.package_name}}/Makefile
+++ b/{{cookiecutter.package_name}}/Makefile
@@ -2,8 +2,6 @@
 # Most actions assume it is operating in a virtual environment where the
 # python command links to the appropriate virtual environment Python.
 
-STYLE_EXCLUDE_LIST := git status --porcelain --ignored | grep "!!" | grep ".py$$" | cut -d " " -f2 | tr "\n" ","
-STYLE_MAX_LINE_LENGTH := 160
 VENVS_DIR := $(HOME)/.venvs
 VENV_DIR := $(VENVS_DIR)/{{cookiecutter.package_name}}
 
@@ -62,19 +60,11 @@ check-coverage:
 	@cd docs/source/coverage; mv index.html coverage.html
 
 
-# help: check-style                    - perform pep8 check
-.PHONY: check-style
-check-style:
-	@pycodestyle --exclude=.git,docs,$(shell $(STYLE_EXCLUDE_LIST)) --ignore=E309,E402 --max-line-length=$(STYLE_MAX_LINE_LENGTH) src/{{cookiecutter.package_name}} tests
+# help: style                          - perform code format compliance check
+.PHONY: style
+style:
+	@black src/{{cookiecutter.package_name}} tests
 
-
-# help: fix-style                      - perform check with autopep8 fixes
-.PHONY: fix-style
-fix-style:
-	@# If there are no files to fix then autopep8 typically returns an error
-	@# because it did not get passed any files to work on. Use xargs -r to
-	@# avoid this problem.
-	@pycodestyle --exclude=.git,docs,$(shell $(STYLE_EXCLUDE_LIST)) --ignore=E309,E402 --max-line-length=$(STYLE_MAX_LINE_LENGTH) src/{{cookiecutter.package_name}} tests -q  | xargs -r autopep8 -i --max-line-length=$(STYLE_MAX_LINE_LENGTH)
 
 
 # help: check-types                    - check type hint annotations

--- a/{{cookiecutter.package_name}}/docs/source/conf.py
+++ b/{{cookiecutter.package_name}}/docs/source/conf.py
@@ -20,7 +20,7 @@
 import os
 import re
 import sys
-from sphinx import apidoc
+from sphinx.ext import apidoc
 # sys.path.insert(0, os.path.abspath('.'))
 
 
@@ -141,7 +141,7 @@ html_sidebars = {
 
 def run_apidoc(_):
     output_path = os.path.join(repo_root, 'docs', 'source', 'api')
-    apidoc.main([None, '--force', '-o', output_path, pkg_root])
+    apidoc.main(['-o', output_path, '-f', pkg_root])
 
 
 def setup(app):

--- a/{{cookiecutter.package_name}}/docs/source/dev/index.rst
+++ b/{{cookiecutter.package_name}}/docs/source/dev/index.rst
@@ -69,20 +69,13 @@ The test code coverage report can be found `here <../coverage/coverage.html>`_
 Code Style
 ==========
 
-Adopting a consistent code style assists with maintenance.
-
-Use the Makefile convenience rule to check code style compliance.
-
-.. code-block:: console
-
-    (venv) $ make check-style
-
-A separate style fix rule is available to automate fixing minor problems.
-More complicated problems will need to be fixed manually.
+Adopting a consistent code style assists with maintenance. This project uses
+the code style formatter called Black. A Makefile convenience rule to enforce
+code style compliance is available.
 
 .. code-block:: console
 
-    (venv) $ make fix-style
+    (venv) $ make style
 
 
 .. _annotations-label:

--- a/{{cookiecutter.package_name}}/examples/quickstart.py
+++ b/{{cookiecutter.package_name}}/examples/quickstart.py
@@ -1,14 +1,16 @@
-'''
+"""
 This example script imports the {{cookiecutter.package_name}} package and
 prints out the version.
-'''
+"""
 
 import {{cookiecutter.package_name}}
 
 
 def main():
-    print(f'{{cookiecutter.package_name}} version: {% raw -%}{{%- endraw %}{{cookiecutter.package_name}}.__version__{% raw -%}}{%- endraw %}')
+    print(
+        f"{{cookiecutter.package_name}} version: {% raw -%}{{%- endraw %}{{cookiecutter.package_name}}.__version__{% raw -%}}{%- endraw %}"
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/{{cookiecutter.package_name}}/requirements.dev.txt
+++ b/{{cookiecutter.package_name}}/requirements.dev.txt
@@ -1,8 +1,7 @@
 -r requirements.txt
-autopep8
+black
 coverage
 mypy
-pycodestyle
 sphinx
 twine
 wheel

--- a/{{cookiecutter.package_name}}/setup.py
+++ b/{{cookiecutter.package_name}}/setup.py
@@ -24,8 +24,17 @@ with open('README.rst', 'r') as f:
 with open('CHANGELOG.rst', 'r') as f:
     changes = f.read()
 
-with open('requirements.txt', 'r') as f:
-    requirements = [line for line in f.read().split('\n') if len(line.strip())]
+def parse_requirements(filename):
+    ''' Load requirements from a pip requirements file '''
+    with open(filename, 'r') as fd:
+        lines = []
+        for line in fd:
+            line.strip()
+            if line and not line.startswith("#"):
+                lines.append(line)
+    return lines
+
+requirements = parse_requirements('requirements.txt')
 
 
 if __name__ == '__main__':

--- a/{{cookiecutter.package_name}}/src/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.package_name}}/src/{{cookiecutter.package_name}}/__init__.py
@@ -1,5 +1,5 @@
-'''
+"""
 {{cookiecutter.package_short_description}}
-'''
+"""
 
-__version__ = '{{cookiecutter.version}}'
+__version__ = "{{cookiecutter.version}}"

--- a/{{cookiecutter.package_name}}/tests/test_basic.py
+++ b/{{cookiecutter.package_name}}/tests/test_basic.py
@@ -4,17 +4,17 @@ import unittest
 
 
 class BasicTestCase(unittest.TestCase):
-    ''' Basic test cases '''
+    """ Basic test cases """
 
     def test_basic(self):
-        ''' check True is True '''
+        """ check True is True """
         self.assertTrue(True)
 
     def test_version(self):
-        ''' check {{cookiecutter.package_name}} exposes a version attribute '''
-        self.assertTrue(hasattr({{cookiecutter.package_name}}, '__version__'))
+        """ check {{cookiecutter.package_name}} exposes a version attribute """
+        self.assertTrue(hasattr({{cookiecutter.package_name}}, "__version__"))
         self.assertIsInstance({{cookiecutter.package_name}}.__version__, str)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/{{cookiecutter.package_name}}/tests/test_examples.py
+++ b/{{cookiecutter.package_name}}/tests/test_examples.py
@@ -1,7 +1,7 @@
-'''
+"""
 To avoid bit-rot in the examples they are tested as part of the unit tests
 suite.
-'''
+"""
 
 import os
 import shlex
@@ -10,44 +10,48 @@ import unittest
 
 
 # Use the current virtual environment when executing the example scripts.
-VENV_DIR = os.environ.get('VIRTUAL_ENV')
+VENV_DIR = os.environ.get("VIRTUAL_ENV")
 
 REPO_DIR = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
 
 @unittest.skipIf(VENV_DIR is None, "VIRTUAL_ENV environment variable is not set")
 class ExamplesTestCase(unittest.TestCase):
-    ''' Check example scripts function.
+    """ Check example scripts function.
 
     This test case assumes it is running in a virtual environment. The same
     virtual environment is activated prior to running the example script
     in a subprocess.
-    '''
+    """
 
     def run_in_venv(self, filepath, timeout=5.0, **kwargs):
-        ''' Run a Python script in a virtual env in a subprocess.
+        """ Run a Python script in a virtual env in a subprocess.
 
         filepath references must be relative to the repo root directory.
-        '''
+        """
         original_cwd = os.getcwd()
         script_dir = os.path.join(REPO_DIR, os.path.dirname(filepath))
         filename = os.path.basename(filepath)
-        args = shlex.split(f'/bin/bash -c "source {VENV_DIR}/bin/activate && python {filename}"')
+        args = shlex.split(
+            f'/bin/bash -c "source {VENV_DIR}/bin/activate && python {filename}"'
+        )
 
         env = {}
-        if os.environ['PATH']:
-            env['PATH'] = os.environ['PATH']
-        if 'LD_LIBRARY_PATH' in os.environ:
-            env['LD_LIBRARY_PATH'] = os.environ['LD_LIBRARY_PATH']
+        if os.environ["PATH"]:
+            env["PATH"] = os.environ["PATH"]
+        if "LD_LIBRARY_PATH" in os.environ:
+            env["LD_LIBRARY_PATH"] = os.environ["LD_LIBRARY_PATH"]
 
         try:
             os.chdir(script_dir)
-            proc = subprocess.Popen(args,
-                                    env=env,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE,
-                                    shell=False,
-                                    **kwargs)
+            proc = subprocess.Popen(
+                args,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=False,
+                **kwargs,
+            )
             _out, _err = proc.communicate(timeout=timeout)
             returncode = proc.returncode
         finally:
@@ -57,10 +61,9 @@ class ExamplesTestCase(unittest.TestCase):
         return success
 
     def test_quickstart_example(self):
-        ''' check quickstart example '''
-        self.assertTrue(
-            self.run_in_venv(os.path.join('examples', 'quickstart.py')))
+        """ check quickstart example """
+        self.assertTrue(self.run_in_venv(os.path.join("examples", "quickstart.py")))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adopt the Black code formatter in place of ``pycodestyle`` and ``autopep8``.
- Update docs to describe new style formatting approach.
- Update Makefile to apply new style formatting approach.
- Update Sphinx API docs generation after a minor issue was observed while performing developer tests as part of style update changes.
- Update code stubs and examples to comply with Black formatter.